### PR TITLE
fix: omit `oneof` fields that have no value set

### DIFF
--- a/plugin/protoc-gen-marshal-zap/main.go
+++ b/plugin/protoc-gen-marshal-zap/main.go
@@ -155,7 +155,8 @@ func handleExplicitPresence(g *protogen.GeneratedFile, f *protogen.Field, genera
 		defer g.P("}")
 	case f.Oneof != nil && !f.Desc.HasOptionalKeyword():
 		// handle oneof fields
-		// TODO
+		g.P("if _, ok := x.Get", f.Oneof.GoName, "().(*Types_", f.GoName, "); ok {")
+		defer g.P("}")
 	case f.Desc.Kind() == protoreflect.MessageKind || f.Desc.Kind() == protoreflect.GroupKind:
 		// handle message fields
 		// TODO

--- a/test/types/types.pb.marshal-zap.go
+++ b/test/types/types.pb.marshal-zap.go
@@ -66,11 +66,17 @@ func (x *Types) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 		enc.AddReflected("other_type_nested_type_val", x.OtherTypeNestedTypeVal)
 	}
 
-	enc.AddString("oneof_string_val", x.GetOneofStringVal())
+	if _, ok := x.GetOneofVal().(*Types_OneofStringVal); ok {
+		enc.AddString("oneof_string_val", x.GetOneofStringVal())
+	}
 
-	enc.AddInt64("oneof_int64_val", x.GetOneofInt64Val())
+	if _, ok := x.GetOneofVal().(*Types_OneofInt64Val); ok {
+		enc.AddInt64("oneof_int64_val", x.GetOneofInt64Val())
+	}
 
-	enc.AddBool("oneof_bool_val", x.GetOneofBoolVal())
+	if _, ok := x.GetOneofVal().(*Types_OneofBoolVal); ok {
+		enc.AddBool("oneof_bool_val", x.GetOneofBoolVal())
+	}
 
 	enc.AddObject("map_val1", zapcore.ObjectMarshalerFunc(func(enc zapcore.ObjectEncoder) error {
 		for k, v := range x.MapVal1 {

--- a/test/types/types_test.go
+++ b/test/types/types_test.go
@@ -121,8 +121,6 @@ func TestTypes_MarshalLogObject(t *testing.T) {
 			"nested_secret_val": "[MASKED]",
 		},
 		"oneof_string_val": "oneof_string",
-		"oneof_int64_val":  int64(0),
-		"oneof_bool_val":   false,
 		"map_val1": map[string]interface{}{
 			"foo": "bar",
 		},
@@ -163,6 +161,8 @@ func TestTypes_MarshalLogObject(t *testing.T) {
 		},
 	}, enc.Fields)
 
+	assert.NotContains(t, enc.Fields, "oneof_int64_val")
+	assert.NotContains(t, enc.Fields, "oneof_bool_val")
 	assert.NotContains(t, enc.Fields, "optional_not_present_val")
 	assert.NotContains(t, enc.Fields, "optional_not_present_enum")
 	assert.NotContains(t, enc.Fields, "optional_not_present_message")

--- a/test/types/types_test.go
+++ b/test/types/types_test.go
@@ -40,7 +40,7 @@ func TestTypes_MarshalLogObject(t *testing.T) {
 			NestedSecretVal: "other_nested_secret",
 		},
 		OneofVal: &Types_OneofStringVal{
-			OneofStringVal: "oneof_string",
+			OneofStringVal: "", // set zero value explicitly
 		},
 		MapVal1: map[string]string{
 			"foo": "bar",
@@ -120,7 +120,7 @@ func TestTypes_MarshalLogObject(t *testing.T) {
 			"nested_string_val": "other_nested_string",
 			"nested_secret_val": "[MASKED]",
 		},
-		"oneof_string_val": "oneof_string",
+		"oneof_string_val": "",
 		"map_val1": map[string]interface{}{
 			"foo": "bar",
 		},


### PR DESCRIPTION
Change to omit `oneof` fields that have no value set.

Previously, `oneof` fields with no value set were always printed.
Therefore, it was not possible to determine whether a zero value field was outputting a set zero value or a zero value because it was not set.

### e.g.
```proto
// foo.proto

message Foo {
  oneof oneof_val {
    string oneof_string_val = 1;
    int64 oneof_int64_val = 2;
  }
}
```

### before
`oneof` fields were always printed.

```go
// foo.pb.marshal-zap.go

func (x *Foo) MarshalLogObject(enc zapcore.ObjectEncoder) error {

	enc.AddString("oneof_string_val", x.GetOneofStringVal())

	enc.AddInt64("oneof_int64_val", x.GetOneofInt64Val())

	return nil
}
```

### after
Omit `oneof` fields that have no value set.

```go
// foo.pb.marshal-zap.go

func (x *Foo) MarshalLogObject(enc zapcore.ObjectEncoder) error {

	if _, ok := x.GetOneofVal().(*Types_OneofStringVal); ok {
		enc.AddString("oneof_string_val", x.GetOneofStringVal())
	}

	if _, ok := x.GetOneofVal().(*Types_OneofInt64Val); ok {
		enc.AddInt64("oneof_int64_val", x.GetOneofInt64Val())
	}

	return nil
}

```